### PR TITLE
Fix validation notification message

### DIFF
--- a/src/utils/hooks/useStorageValidation.tsx
+++ b/src/utils/hooks/useStorageValidation.tsx
@@ -30,7 +30,10 @@ const useStorageValidation = () => {
     }
 
     if (newErrors && Object.keys(newErrors).length > 0) {
-      showNotification("error", newErrors[0]!); // エラーの最初のメッセージを返す
+      const firstKey = Object.keys(newErrors)[0];
+      if (firstKey) {
+        showNotification("error", newErrors[firstKey]);
+      }
     }
 
     return newErrors;


### PR DESCRIPTION
## Summary
- ensure the first validation error message is shown by using the key name in `useStorageValidation`

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6859394b59208328aff88b54594cf72e