### PR TITLE
Add storage assignment dialog

### DIFF
--- a/src/app/task/AssignStorageDialog.tsx
+++ b/src/app/task/AssignStorageDialog.tsx
@@ -1,0 +1,135 @@
+"use client";
+
+import { useState } from "react";
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Button } from "@/components/ui/button";
+import { Label } from "@/components/ui/label";
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from "@/components/ui/popover";
+import {
+  Command,
+  CommandEmpty,
+  CommandGroup,
+  CommandInput,
+  CommandItem,
+  CommandList,
+} from "@/components/ui/command";
+import { Check, ChevronsUpDown, MapPin } from "lucide-react";
+import { cn } from "@/lib/utils";
+import { TaskInput } from "@/utils/interface";
+
+interface Props {
+  open: boolean;
+  setOpen: (open: boolean) => void;
+  selectedItem: TaskInput | null;
+  storageOptions: string[];
+  onAssign: (storageId: string) => void;
+}
+
+const AssignStorageDialog = ({
+  open,
+  setOpen,
+  selectedItem,
+  storageOptions,
+  onAssign,
+}: Props) => {
+  const [selectedStorageId, setSelectedStorageId] = useState("");
+  const [comboboxOpen, setComboboxOpen] = useState(false);
+
+  const handleAssign = () => {
+    if (!selectedStorageId) return;
+    onAssign(selectedStorageId);
+    setSelectedStorageId("");
+    setOpen(false);
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={setOpen}>
+      <DialogContent className="max-w-md">
+        <DialogHeader>
+          <DialogTitle className="flex items-center gap-2">
+            <MapPin className="h-5 w-5" />
+            保管庫割当
+          </DialogTitle>
+        </DialogHeader>
+
+        {selectedItem && (
+          <div className="p-3 bg-gray-50 rounded-lg">
+            <div className="font-medium">
+              {selectedItem.client?.client_name}
+            </div>
+            <div className="text-sm text-gray-600">
+              {selectedItem.car?.car_number}
+            </div>
+          </div>
+        )}
+
+        <div className="space-y-2">
+          <Label>保管庫ID</Label>
+          <Popover open={comboboxOpen} onOpenChange={setComboboxOpen}>
+            <PopoverTrigger asChild>
+              <Button
+                variant="outline"
+                role="combobox"
+                aria-expanded={comboboxOpen}
+                className="w-full justify-between"
+              >
+                {selectedStorageId || "保管庫を選択..."}
+                <ChevronsUpDown className="ml-2 h-4 w-4 shrink-0 opacity-50" />
+              </Button>
+            </PopoverTrigger>
+            <PopoverContent className="w-full p-0">
+              <Command>
+                <CommandInput placeholder="保管庫IDを検索..." />
+                <CommandList>
+                  <CommandEmpty>該当する保管庫が見つかりません。</CommandEmpty>
+                  <CommandGroup>
+                    {storageOptions.map((id) => (
+                      <CommandItem
+                        key={id}
+                        value={id}
+                        onSelect={(currentValue) => {
+                          setSelectedStorageId(
+                            currentValue === selectedStorageId ? "" : currentValue
+                          );
+                          setComboboxOpen(false);
+                        }}
+                      >
+                        <Check
+                          className={cn(
+                            "mr-2 h-4 w-4",
+                            selectedStorageId === id ? "opacity-100" : "opacity-0"
+                          )}
+                        />
+                        <span className="font-mono">{id}</span>
+                      </CommandItem>
+                    ))}
+                  </CommandGroup>
+                </CommandList>
+              </Command>
+            </PopoverContent>
+          </Popover>
+        </div>
+
+        <div className="flex justify-end gap-3 pt-4 border-t">
+          <Button variant="outline" onClick={() => setOpen(false)}>
+            キャンセル
+          </Button>
+          <Button onClick={handleAssign} disabled={!selectedStorageId}>
+            割当
+          </Button>
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+};
+
+export default AssignStorageDialog;

--- a/src/app/task/ReceptionList.tsx
+++ b/src/app/task/ReceptionList.tsx
@@ -14,7 +14,8 @@ import { TaskInput } from "@/utils/interface";
 import { Clock, User, Hash, Car, Package } from "lucide-react";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
-import EditForm from "./EditForm"; // Assuming EditForm is in the same directory
+import EditForm from "./EditForm";
+import AssignStorageDialog from "./AssignStorageDialog";
 
 interface Props {
   tasks: TaskInput[];
@@ -23,10 +24,28 @@ interface Props {
 const ReceptionList = ({ tasks }: Props) => {
   const [selectedItem, setSelectedItem] = useState<TaskInput | null>(null);
   const [isMaintenanceDialogOpen, setIsMaintenanceDialogOpen] = useState(false);
+  const [isStorageDialogOpen, setIsStorageDialogOpen] = useState(false);
+  const [taskList, setTaskList] = useState<TaskInput[]>(tasks);
 
   const handleMaintenanceEdit = (item: TaskInput) => {
     setSelectedItem(item);
     setIsMaintenanceDialogOpen(true);
+  };
+
+  const handleStorageAssignOpen = (item: TaskInput) => {
+    setSelectedItem(item);
+    setIsStorageDialogOpen(true);
+  };
+
+  const handleStorageAssign = (storageId: string) => {
+    if (!selectedItem) return;
+    setTaskList((prev) =>
+      prev.map((t) =>
+        t.id === selectedItem.id
+          ? { ...t, storage_id: storageId, status: "complete" }
+          : t
+      )
+    );
   };
 
   const getActionButton = (item: TaskInput) => {
@@ -52,7 +71,7 @@ const ReceptionList = ({ tasks }: Props) => {
           >
             編集
           </Button>
-          <Button size="default">
+          <Button size="default" onClick={() => handleStorageAssignOpen(item)}>
             {item.storage_id ? "保管庫ID変更" : "保管庫ID割当"}
           </Button>
         </div>
@@ -67,7 +86,9 @@ const ReceptionList = ({ tasks }: Props) => {
           >
             編集
           </Button>
-          <Button size="default">保管庫ID割当</Button>
+          <Button size="default" onClick={() => handleStorageAssignOpen(item)}>
+            保管庫ID割当
+          </Button>
         </div>
       );
     }
@@ -87,7 +108,7 @@ const ReceptionList = ({ tasks }: Props) => {
       <CardHeader>
         <CardTitle className="flex items-center gap-2">
           <Clock className="h-5 w-5" />
-          受付済み予約 ({tasks.length}件)
+          受付済み予約 ({taskList.length}件)
         </CardTitle>
       </CardHeader>
       <CardContent>
@@ -96,6 +117,15 @@ const ReceptionList = ({ tasks }: Props) => {
           setIsMaintenanceDialogOpen={setIsMaintenanceDialogOpen}
           selectedItem={selectedItem}
           setSelectedItem={setSelectedItem}
+        />
+        <AssignStorageDialog
+          open={isStorageDialogOpen}
+          setOpen={setIsStorageDialogOpen}
+          selectedItem={selectedItem}
+          storageOptions={Array.from({ length: 20 }, (_, i) =>
+            `S-${(i + 1).toString().padStart(3, "0")}`
+          )}
+          onAssign={handleStorageAssign}
         />
         <div className="overflow-x-auto">
           <Table>
@@ -137,7 +167,7 @@ const ReceptionList = ({ tasks }: Props) => {
               </TableRow>
             </TableHeader>
             <TableBody>
-              {tasks.map((item) => (
+              {taskList.map((item) => (
                 <TableRow key={item.id} className="hover:bg-gray-50">
                   <TableCell className="font-medium">
                     #{item.id?.toString().padStart(3, "0") || "未割当"}


### PR DESCRIPTION
## Summary
- add AssignStorageDialog component with combobox UI to choose storage ID
- integrate AssignStorageDialog into ReceptionList and update local task data

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_68595c40797c8328abff4b87fdec61b7