### PR TITLE
Connect storage assignment to backend

### DIFF
--- a/src/app/task/AssignStorageDialog.tsx
+++ b/src/app/task/AssignStorageDialog.tsx
@@ -1,0 +1,136 @@
+"use client";
+
+import { useState } from "react";
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Button } from "@/components/ui/button";
+import { Label } from "@/components/ui/label";
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from "@/components/ui/popover";
+import {
+  Command,
+  CommandEmpty,
+  CommandGroup,
+  CommandInput,
+  CommandItem,
+  CommandList,
+} from "@/components/ui/command";
+import { Check, ChevronsUpDown, MapPin } from "lucide-react";
+import { cn } from "@/lib/utils";
+import { TaskInput } from "@/utils/interface";
+import useAssignStorage from "@/utils/hooks/useAssignStorage";
+
+interface Props {
+  open: boolean;
+  setOpen: (open: boolean) => void;
+  selectedItem: TaskInput | null;
+  onAssigned?: (storageId: string) => void;
+}
+
+const AssignStorageDialog = ({
+  open,
+  setOpen,
+  selectedItem,
+  onAssigned,
+}: Props) => {
+  const [selectedStorageId, setSelectedStorageId] = useState("");
+  const [comboboxOpen, setComboboxOpen] = useState(false);
+  const { options, assignStorage, loading } = useAssignStorage();
+
+  const handleAssign = async () => {
+    if (!selectedStorageId || !selectedItem) return;
+    await assignStorage(selectedItem, selectedStorageId);
+    onAssigned?.(selectedStorageId);
+    setSelectedStorageId("");
+    setOpen(false);
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={setOpen}>
+      <DialogContent className="max-w-md">
+        <DialogHeader>
+          <DialogTitle className="flex items-center gap-2">
+            <MapPin className="h-5 w-5" />
+            保管庫割当
+          </DialogTitle>
+        </DialogHeader>
+
+        {selectedItem && (
+          <div className="p-3 bg-gray-50 rounded-lg">
+            <div className="font-medium">
+              {selectedItem.client?.client_name}
+            </div>
+            <div className="text-sm text-gray-600">
+              {selectedItem.car?.car_number}
+            </div>
+          </div>
+        )}
+
+        <div className="space-y-2">
+          <Label>保管庫ID</Label>
+          <Popover open={comboboxOpen} onOpenChange={setComboboxOpen}>
+            <PopoverTrigger asChild>
+              <Button
+                variant="outline"
+                role="combobox"
+                aria-expanded={comboboxOpen}
+                className="w-full justify-between"
+              >
+                {selectedStorageId || "保管庫を選択..."}
+                <ChevronsUpDown className="ml-2 h-4 w-4 shrink-0 opacity-50" />
+              </Button>
+            </PopoverTrigger>
+            <PopoverContent className="w-full p-0">
+              <Command>
+                <CommandInput placeholder="保管庫IDを検索..." />
+                <CommandList>
+                  <CommandEmpty>該当する保管庫が見つかりません。</CommandEmpty>
+                  <CommandGroup>
+                    {options.map((id) => (
+                      <CommandItem
+                        key={id}
+                        value={id}
+                        onSelect={(currentValue) => {
+                          setSelectedStorageId(
+                            currentValue === selectedStorageId ? "" : currentValue
+                          );
+                          setComboboxOpen(false);
+                        }}
+                      >
+                        <Check
+                          className={cn(
+                            "mr-2 h-4 w-4",
+                            selectedStorageId === id ? "opacity-100" : "opacity-0"
+                          )}
+                        />
+                        <span className="font-mono">{id}</span>
+                      </CommandItem>
+                    ))}
+                  </CommandGroup>
+                </CommandList>
+              </Command>
+            </PopoverContent>
+          </Popover>
+        </div>
+
+        <div className="flex justify-end gap-3 pt-4 border-t">
+          <Button variant="outline" onClick={() => setOpen(false)}>
+            キャンセル
+          </Button>
+          <Button onClick={handleAssign} disabled={!selectedStorageId || loading}>
+            割当
+          </Button>
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+};
+
+export default AssignStorageDialog;

--- a/src/app/task/ReceptionList.tsx
+++ b/src/app/task/ReceptionList.tsx
@@ -14,7 +14,8 @@ import { TaskInput } from "@/utils/interface";
 import { Clock, User, Hash, Car, Package } from "lucide-react";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
-import EditForm from "./EditForm"; // Assuming EditForm is in the same directory
+import EditForm from "./EditForm";
+import AssignStorageDialog from "./AssignStorageDialog";
 
 interface Props {
   tasks: TaskInput[];
@@ -23,10 +24,30 @@ interface Props {
 const ReceptionList = ({ tasks }: Props) => {
   const [selectedItem, setSelectedItem] = useState<TaskInput | null>(null);
   const [isMaintenanceDialogOpen, setIsMaintenanceDialogOpen] = useState(false);
+  const [isStorageDialogOpen, setIsStorageDialogOpen] = useState(false);
+  const [taskList, setTaskList] = useState<TaskInput[]>(tasks);
 
   const handleMaintenanceEdit = (item: TaskInput) => {
     setSelectedItem(item);
     setIsMaintenanceDialogOpen(true);
+  };
+
+  const handleStorageAssignOpen = (item: TaskInput) => {
+    setSelectedItem(item);
+    setIsStorageDialogOpen(true);
+  };
+
+  const handleStorageAssign = (storageId: string) => {
+    if (!selectedItem) return;
+    setTaskList((prev) =>
+      prev.map((t) =>
+        t.id === selectedItem.id
+          ? { ...t, storage_id: storageId, status: "complete" }
+          : t
+      )
+    );
+    setIsStorageDialogOpen(false);
+    setSelectedItem(null);
   };
 
   const getActionButton = (item: TaskInput) => {
@@ -52,7 +73,7 @@ const ReceptionList = ({ tasks }: Props) => {
           >
             編集
           </Button>
-          <Button size="default">
+          <Button size="default" onClick={() => handleStorageAssignOpen(item)}>
             {item.storage_id ? "保管庫ID変更" : "保管庫ID割当"}
           </Button>
         </div>
@@ -67,7 +88,9 @@ const ReceptionList = ({ tasks }: Props) => {
           >
             編集
           </Button>
-          <Button size="default">保管庫ID割当</Button>
+          <Button size="default" onClick={() => handleStorageAssignOpen(item)}>
+            保管庫ID割当
+          </Button>
         </div>
       );
     }
@@ -87,7 +110,7 @@ const ReceptionList = ({ tasks }: Props) => {
       <CardHeader>
         <CardTitle className="flex items-center gap-2">
           <Clock className="h-5 w-5" />
-          受付済み予約 ({tasks.length}件)
+          受付済み予約 ({taskList.length}件)
         </CardTitle>
       </CardHeader>
       <CardContent>
@@ -96,6 +119,12 @@ const ReceptionList = ({ tasks }: Props) => {
           setIsMaintenanceDialogOpen={setIsMaintenanceDialogOpen}
           selectedItem={selectedItem}
           setSelectedItem={setSelectedItem}
+        />
+        <AssignStorageDialog
+          open={isStorageDialogOpen}
+          setOpen={setIsStorageDialogOpen}
+          selectedItem={selectedItem}
+          onAssigned={handleStorageAssign}
         />
         <div className="overflow-x-auto">
           <Table>
@@ -137,7 +166,7 @@ const ReceptionList = ({ tasks }: Props) => {
               </TableRow>
             </TableHeader>
             <TableBody>
-              {tasks.map((item) => (
+              {taskList.map((item) => (
                 <TableRow key={item.id} className="hover:bg-gray-50">
                   <TableCell className="font-medium">
                     #{item.id?.toString().padStart(3, "0") || "未割当"}

--- a/src/utils/hooks/useAssignStorage.tsx
+++ b/src/utils/hooks/useAssignStorage.tsx
@@ -1,0 +1,88 @@
+"use client";
+
+import { useCallback, useEffect, useState } from "react";
+import { TaskInput, StorageData } from "@/utils/interface";
+import {
+  getAllMasterStorages,
+  pushNewStorageLog,
+  upsertStorage,
+  updateTaskStatus,
+} from "@/utils/supabaseFunction";
+import { getYearAndSeason } from "@/utils/globalFunctions";
+import { useNotification } from "./useNotification";
+
+interface UseAssignStorageReturn {
+  options: string[];
+  loading: boolean;
+  assignStorage: (task: TaskInput, storageId: string) => Promise<void>;
+}
+
+const useAssignStorage = (): UseAssignStorageReturn => {
+  const [options, setOptions] = useState<string[]>([]);
+  const [loading, setLoading] = useState(false);
+  const { showNotification } = useNotification();
+
+  const fetchOptions = useCallback(async () => {
+    try {
+      setLoading(true);
+      const storages = await getAllMasterStorages();
+      const available = storages
+        .filter(
+          (s) => !s.car_id && !s.client_id && !s.tire_state_id
+        )
+        .map((s) => s.id as string);
+      setOptions(available);
+    } catch (err) {
+      const msg =
+        err instanceof Error
+          ? err.message
+          : "保管庫情報の取得に失敗しました";
+      showNotification("error", msg);
+    } finally {
+      setLoading(false);
+    }
+  }, [showNotification]);
+
+  useEffect(() => {
+    fetchOptions();
+  }, [fetchOptions]);
+
+  const assignStorage = useCallback(
+    async (task: TaskInput, storageId: string) => {
+      try {
+        setLoading(true);
+        const storageData: StorageData = {
+          id: storageId,
+          car_id: task.car?.id ?? null,
+          client_id: task.client?.id ?? null,
+          tire_state_id: task.tire_state?.id ?? null,
+        };
+        await upsertStorage(storageData);
+
+        const { year, season } = getYearAndSeason();
+        await pushNewStorageLog({ year, season, storage: storageData });
+        if (task.id) {
+          await updateTaskStatus(task.id, "complete");
+        }
+        showNotification("success", "保管庫を割り当てました");
+        fetchOptions();
+      } catch (err) {
+        const msg =
+          err instanceof Error ? err.message : "保管庫割り当てに失敗しました";
+        showNotification("error", msg);
+        throw err;
+      } finally {
+        setLoading(false);
+      }
+    },
+    [fetchOptions, showNotification]
+  );
+
+  return {
+    options,
+    loading,
+    assignStorage,
+  };
+};
+
+export default useAssignStorage;


### PR DESCRIPTION
## Summary
- add `useAssignStorage` hook to fetch available storages and write results to Supabase
- update `AssignStorageDialog` to use the new hook and send assignments
- refresh task list in `ReceptionList` when storage is assigned

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_68595c40797c8328abff4b87fdec61b7