### PR TITLE
Implement storage save confirmation UI

### DIFF
--- a/src/app/task/SaveTaskDialog.tsx
+++ b/src/app/task/SaveTaskDialog.tsx
@@ -5,10 +5,23 @@ import {
   DialogContent,
   DialogHeader,
   DialogTitle,
+  DialogFooter,
 } from "@/components/ui/dialog";
-import CustomerInfoCard from "./components/CustomerInfoCard";
-
-import InspectionInfoCard from "./components/InspectionInfoCard";
+import { Button } from "@/components/ui/button";
+import {
+  Card,
+  CardContent,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
 
 interface Props {
   open: boolean;
@@ -17,15 +30,179 @@ interface Props {
   onSave: () => void;
 }
 
-const SaveTaskDialog = ({ open, setOpen, selectedData }: Props) => {
+const SaveTaskDialog = ({ open, setOpen, selectedData, onSave }: Props) => {
+  if (!selectedData) return null;
+
+  const formatDate = (date?: Date | string) => {
+    if (!date) return "-";
+    const d = typeof date === "string" ? new Date(date) : date;
+    return d.toLocaleDateString();
+  };
+
+  const close = () => setOpen(false);
+
   return (
     <Dialog open={open} onOpenChange={setOpen} modal>
-      <DialogHeader>
-        <DialogTitle>以下のデータで保存してもよろしいでしょうか？</DialogTitle>
-      </DialogHeader>
-      <DialogContent className="max-h-[80vh] overflow-y-auto bg-gray-50 p-6">
-        <CustomerInfoCard selectedItem={selectedData} />
-        <InspectionInfoCard selectedItem={selectedData} />
+      <DialogContent className="max-w-3xl max-h-[80vh] overflow-y-auto bg-gray-50">
+        <DialogHeader>
+          <DialogTitle>以下のデータを保管庫に保存しますか？</DialogTitle>
+        </DialogHeader>
+
+        <div className="space-y-6 py-4">
+          {/* 顧客情報 */}
+          <Card>
+            <CardHeader>
+              <CardTitle className="text-lg font-semibold">顧客情報</CardTitle>
+            </CardHeader>
+            <CardContent className="grid grid-cols-1 md:grid-cols-2 gap-4">
+              <div>
+                <p className="text-sm text-gray-600">顧客名</p>
+                <p className="font-medium">
+                  {selectedData.client?.client_name || "-"}
+                </p>
+              </div>
+              <div>
+                <p className="text-sm text-gray-600">電話番号</p>
+                <p className="font-medium">
+                  {selectedData.client?.phone || "-"}
+                </p>
+              </div>
+              <div>
+                <p className="text-sm text-gray-600">車種</p>
+                <p className="font-medium">
+                  {selectedData.car?.car_model || "-"}
+                </p>
+              </div>
+              <div>
+                <p className="text-sm text-gray-600">車ナンバー</p>
+                <p className="font-medium">
+                  {selectedData.car?.car_number || "-"}
+                </p>
+              </div>
+            </CardContent>
+          </Card>
+
+          {/* タイヤ基礎情報 */}
+          <Card>
+            <CardHeader>
+              <CardTitle className="text-lg font-semibold">タイヤ基礎情報</CardTitle>
+            </CardHeader>
+            <CardContent className="grid grid-cols-1 md:grid-cols-2 gap-4">
+              <div>
+                <p className="text-sm text-gray-600">タイヤメーカー</p>
+                <p className="font-medium">
+                  {selectedData.tire_state?.tire_maker || "-"}
+                </p>
+              </div>
+              <div>
+                <p className="text-sm text-gray-600">パターン</p>
+                <p className="font-medium">
+                  {selectedData.tire_state?.tire_pattern || "-"}
+                </p>
+              </div>
+              <div>
+                <p className="text-sm text-gray-600">サイズ</p>
+                <p className="font-medium">
+                  {selectedData.tire_state?.tire_size || "-"}
+                </p>
+              </div>
+              <div>
+                <p className="text-sm text-gray-600">製造年</p>
+                <p className="font-medium">
+                  {selectedData.tire_state?.manufacture_year ?? "-"}
+                </p>
+              </div>
+              <div>
+                <p className="text-sm text-gray-600">エアプレッシャー</p>
+                <p className="font-medium">
+                  {selectedData.tire_state?.air_pressure ?? "-"}
+                </p>
+              </div>
+            </CardContent>
+          </Card>
+
+          {/* 整備項目 */}
+          <Card>
+            <CardHeader>
+              <CardTitle className="text-lg font-semibold">整備項目</CardTitle>
+            </CardHeader>
+            <CardContent className="p-0">
+              <Table>
+                <TableHeader>
+                  <TableRow>
+                    <TableHead className="w-32">項目</TableHead>
+                    <TableHead>状態</TableHead>
+                    <TableHead>交換</TableHead>
+                    <TableHead>備考</TableHead>
+                  </TableRow>
+                </TableHeader>
+                <TableBody>
+                  {[
+                    { label: "タイヤ", data: selectedData.tire_state?.tire_inspection },
+                    { label: "ワイパーゴム", data: selectedData.tire_state?.wiper_inspection },
+                    { label: "エンジンオイル", data: selectedData.tire_state?.oil_inspection },
+                    { label: "バッテリー", data: selectedData.tire_state?.battery_inspection },
+                  ].map((row) => (
+                    <TableRow key={row.label}>
+                      <TableCell className="font-medium">{row.label}</TableCell>
+                      <TableCell>{row.data?.state || "-"}</TableCell>
+                      <TableCell>
+                        {row.data
+                          ? row.data.is_exchange
+                            ? "交換済"
+                            : "未交換"
+                          : "-"}
+                      </TableCell>
+                      <TableCell>{row.data?.note || "-"}</TableCell>
+                    </TableRow>
+                  ))}
+                  <TableRow>
+                    <TableCell className="font-medium">その他</TableCell>
+                    <TableCell>-</TableCell>
+                    <TableCell>-</TableCell>
+                    <TableCell>
+                      {selectedData.tire_state?.other_inspection || "-"}
+                    </TableCell>
+                  </TableRow>
+                </TableBody>
+              </Table>
+            </CardContent>
+          </Card>
+
+          {/* 重要情報 */}
+          <Card>
+            <CardHeader>
+              <CardTitle className="text-lg font-semibold">重要情報</CardTitle>
+            </CardHeader>
+            <CardContent className="grid grid-cols-1 md:grid-cols-3 gap-4">
+              <div>
+                <p className="text-sm text-gray-600">走行距離数</p>
+                <p className="font-medium">
+                  {selectedData.tire_state?.drive_distance ?? "-"}
+                </p>
+              </div>
+              <div>
+                <p className="text-sm text-gray-600">車検日</p>
+                <p className="font-medium">
+                  {formatDate(selectedData.tire_state?.inspection_date)}
+                </p>
+              </div>
+              <div>
+                <p className="text-sm text-gray-600">次回のテーマ</p>
+                <p className="font-medium">
+                  {selectedData.tire_state?.next_theme || "-"}
+                </p>
+              </div>
+            </CardContent>
+          </Card>
+        </div>
+
+        <DialogFooter className="pt-4">
+          <Button variant="outline" onClick={close}>
+            キャンセル
+          </Button>
+          <Button onClick={onSave}>保存</Button>
+        </DialogFooter>
       </DialogContent>
     </Dialog>
   );


### PR DESCRIPTION
## Summary
- enhance SaveTaskDialog to show detailed info about storage save
- show customer info, tire basics, inspection items, and important info
- add Save and Cancel actions

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68655b6eb268832887a9298383f1e346